### PR TITLE
lower Dart SDK to 2.18.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.1
 homepage: https://github.com/CyberAgentAI/caretailbooster-sdk-flutter
 
 environment:
-  sdk: ">=3.4.0 <4.0.0"
+  sdk: ">=2.18.0 <4.0.0"
   flutter: ">=3.3.0"
 
 dependencies:


### PR DESCRIPTION
## 対応内容

- Dart SDKの最小バージョン要件を2.18.0に変更しました。