### PR TITLE
fix version bump workflow

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -77,19 +77,10 @@ jobs:
           sed -i "s/ref: $CURRENT_VERSION/ref: $NEW_VERSION/g" example/pubspec.yaml
 
       - name: Create Pull Request
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-          git add pubspec.yaml example/pubspec.yaml
-          git commit -m "Bump version to ${{ steps.version_bump.outputs.new_version }}"
-          git push origin ${{ steps.create_branch.outputs.branch_name }}
-
-      - name: Create PR
         uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "Bump version to ${{ steps.version_bump.outputs.new_version }}"
           title: "Bump version to ${{ steps.version_bump.outputs.new_version }}"
           body: |
             Version update PR


### PR DESCRIPTION
## 対応内容
- バージョンアップのワークフローを修正
  - 手動でCommit、Pushを実行すると、`create-pull-request`アクションが競合してPRが作成されないようになっていました。
  - `create-pull-request`アクションのみを使う形に修正しました。
  - https://github.com/CyberAgentAI/caretailbooster-sdk-flutter/actions/runs/14698735666/job/41244385907
