### PR TITLE
Feature/fix swift package manager integration

### DIFF
--- a/ios/caretailbooster_sdk/Package.resolved
+++ b/ios/caretailbooster_sdk/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CyberAgentAI/caretailbooster-sdk-ios.git",
       "state" : {
-        "revision" : "26355832cace46107acce0e049a1e1c06ad9ab8e",
-        "version" : "1.0.0"
+        "revision" : "f4ce30160ee2558e22537e4d5408930f6a39619a",
+        "version" : "1.0.1"
       }
     }
   ],

--- a/ios/caretailbooster_sdk/Package.resolved
+++ b/ios/caretailbooster_sdk/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "caretailbooster-sdk-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/CyberAgentAI/caretailbooster-sdk-ios.git",
+      "state" : {
+        "revision" : "26355832cace46107acce0e049a1e1c06ad9ab8e",
+        "version" : "1.0.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/ios/caretailbooster_sdk/Package.swift
+++ b/ios/caretailbooster_sdk/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
         .iOS("13.0")
     ],
     products: [
-        .library(name: "caretailbooster-sdk", targets: ["caretailbooster_sdk"])
+        .library(name: "CaRetailBoosterSDK", targets: ["caretailbooster_sdk"])
     ],
     dependencies: [
         .package(url: "https://github.com/CyberAgentAI/caretailbooster-sdk-ios.git", from: "0.1.3")

--- a/ios/caretailbooster_sdk/Package.swift
+++ b/ios/caretailbooster_sdk/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         .library(name: "CaRetailBoosterSDK", targets: ["caretailbooster_sdk"])
     ],
     dependencies: [
-        .package(url: "https://github.com/CyberAgentAI/caretailbooster-sdk-ios.git", from: "0.1.3")
+        .package(url: "https://github.com/CyberAgentAI/caretailbooster-sdk-ios.git", from: "1.0.1")
     ],
     targets: [
         .target(

--- a/ios/caretailbooster_sdk/Sources/caretailbooster_sdk/CaRetailBoosterSdkPlugin.swift
+++ b/ios/caretailbooster_sdk/Sources/caretailbooster_sdk/CaRetailBoosterSdkPlugin.swift
@@ -1,7 +1,6 @@
 import Flutter
 import UIKit
 import SwiftUI
-import CaRetailBoosterSDK
 
 public class CaRetailBoosterSdkPlugin: NSObject, FlutterPlugin {
   public static func register(with registrar: FlutterPluginRegistrar) {


### PR DESCRIPTION
## 対応内容
- ライブラリ名を`CaRetailBoosterSDK`に変更しました。
- Package.resolved の追加しました。
- 不要なimportを削除しました。
- また、iOS SDKを`1.0.1`にアップデートしました。