### PR TITLE
Fix/android hasads always false

### DIFF
--- a/android/src/main/kotlin/com/example/caretailbooster_sdk/CaRetailBoosterView.kt
+++ b/android/src/main/kotlin/com/example/caretailbooster_sdk/CaRetailBoosterView.kt
@@ -23,6 +23,11 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.foundation.background
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
 
 class CaRetailBoosterView(
     private val context: Context,
@@ -113,10 +118,20 @@ class CaRetailBoosterView(
             options = options
         )
 
+        var isFirst by remember { mutableStateOf(true) }
+        var prevAds by remember { mutableStateOf<List<Any>>(emptyList()) }
+    
         // 広告の有無を通知
-        val hasAds = caRetailBoosterResult.ads.isNotEmpty()
-        Handler(Looper.getMainLooper()).post {
-            channel.invokeMethod(CaRetailBoosterMethodCallType.HAS_ADS.methodName, hasAds)
+        LaunchedEffect(caRetailBoosterResult.ads.hashCode()) {
+            val ads = caRetailBoosterResult.ads
+            if (isFirst) {
+                isFirst = false
+            } else if (prevAds != ads) {
+                Handler(Looper.getMainLooper()).post {
+                    channel.invokeMethod(CaRetailBoosterMethodCallType.HAS_ADS.methodName, ads.isNotEmpty())
+                }
+            }
+            prevAds = ads
         }
 
         // 広告の表示

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
     # path: ../
     git:
       url: https://github.com/CyberAgentAI/caretailbooster-sdk-flutter
-      ref: 0.5.1
+      ref: 0.5.2
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/ios/caretailbooster_sdk.podspec
+++ b/ios/caretailbooster_sdk.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'caretailbooster_sdk'
-  s.version          = '0.5.1'
+  s.version          = '0.5.2'
   s.summary          = 'Flutter plugin for CaRetailBooster SDK'
   s.homepage         = 'https://github.com/CyberAgentAI/caretailbooster-sdk-flutter'
   s.license          = { :file => '../LICENSE' }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: caretailbooster_sdk
 description: "A new Flutter plugin project."
-version: 0.5.1
+version: 0.5.2
 homepage: https://github.com/CyberAgentAI/caretailbooster-sdk-flutter
 
 environment:


### PR DESCRIPTION
## 対応内容
- Androidで`hasAds`が常に`false`になる問題を修正
  - 初期値のみが通知されるようになっていため常に`false`の状態になっていた。
  - 初期値は無視しつつ、更新があれば通知するように修正しました。
- SDKを`0.5.2`にバージョンアップ