### PR TITLE
Feature/update native sdk

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -70,7 +70,7 @@ android {
         implementation("androidx.media3:media3-ui:1.4.1")
         implementation("androidx.media3:media3-exoplayer:1.4.1")
         implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.0")
-        implementation("com.retaiboo:caretailbooster-sdk:0.1.11")
+        implementation("com.retaiboo:caretailbooster-sdk:1.0.0")
     }
 
     testOptions {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -28,7 +28,7 @@ apply plugin: "kotlin-android"
 android {
     namespace = "com.example.caretailbooster_sdk"
 
-    compileSdk = 34
+    compileSdk = 35
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -33,7 +33,7 @@ target 'Runner' do
 
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
   
-  pod 'CaRetailBoosterSDK', :git => 'https://github.com/CyberAgentAI/caretailbooster-sdk-ios.git', :tag => '1.4.2'
+  pod 'CaRetailBoosterSDK', :git => 'https://github.com/CyberAgentAI/caretailbooster-sdk-ios.git', :tag => '1.4.3'
 end
 
 post_install do |installer|

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
     # path: ../
     git:
       url: https://github.com/CyberAgentAI/caretailbooster-sdk-flutter
-      ref: 0.5.4
+      ref: 1.0.0
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/ios/caretailbooster_sdk.podspec
+++ b/ios/caretailbooster_sdk.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'CaRetailBoosterSDK', '1.4.2'
+  s.dependency 'CaRetailBoosterSDK', '1.4.3'
   s.platform = :ios, '13.0'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
   s.swift_version = '5.0'

--- a/ios/caretailbooster_sdk.podspec
+++ b/ios/caretailbooster_sdk.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'caretailbooster_sdk'
-  s.version          = '0.5.3'
+  s.version          = '1.0.0'
   s.summary          = 'Flutter plugin for CaRetailBooster SDK'
   s.homepage         = 'https://github.com/CyberAgentAI/caretailbooster-sdk-flutter'
   s.license          = { :file => '../LICENSE' }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: caretailbooster_sdk
 description: "A new Flutter plugin project."
-version: 0.5.4
+version: 1.0.0
 homepage: https://github.com/CyberAgentAI/caretailbooster-sdk-flutter
 
 environment:


### PR DESCRIPTION
## 対応内容
- iOS SDKを`1.4.3`にバージョンアップ
- Android SDKを`1.0.0`にバージョンアップ
- compileSdkを35に変更
 - SDKを`1.0.0`にバージョンアップ