### PR TITLE
fix horizontal ScrollView indicator flag

### DIFF
--- a/ios/Classes/SwiftUIView.swift
+++ b/ios/Classes/SwiftUIView.swift
@@ -103,7 +103,7 @@ class SwiftUIView: NSObject, FlutterPlatformView {
     }
 
     private func createAdScrollView(with adViews: [AnyView]) -> some View {
-        ScrollView(.horizontal, showsIndicators: hiddenIndicators) {
+        ScrollView(.horizontal, showsIndicators: !hiddenIndicators) {
             HStack(spacing: itemSpacing ?? 0) {
                 if let leadingMargin = leadingMargin, leadingMargin > 0 {
                     Spacer().frame(width: leadingMargin)


### PR DESCRIPTION
## 対応内容
- iOSのスクロールインジケータのフラグの反転が漏れてて、表示非表示が逆になっていたのを修正しました。