### PR TITLE
fix: update android sdk version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -70,7 +70,7 @@ android {
         implementation("androidx.media3:media3-ui:1.4.1")
         implementation("androidx.media3:media3-exoplayer:1.4.1")
         implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.0")
-        implementation("com.retaiboo:caretailbooster-sdk:1.0.3")
+        implementation("com.retaiboo:caretailbooster-sdk:1.0.4")
     }
 
     testOptions {


### PR DESCRIPTION
- android sdkのバージョンを更新
- iOSの他修正と同時に反映したいので、Flutter SDK自体のバージョンアップはこのPRでは行わない