### PR TITLE
 disable Impeller to fix Android 16 WebView black screen

### DIFF
--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -31,6 +31,10 @@
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
+        <!-- Disable Impeller rendering backend to fix Android 16 WebView issues -->
+        <meta-data
+            android:name="io.flutter.embedding.android.EnableImpeller"
+            android:value="false" />
     </application>
     <!-- Required to query activities that can process text, see:
          https://developer.android.com/training/package-visibility and


### PR DESCRIPTION
## 対応内容
### バグ内容
  - Android 16デバイスでExampleアプリ画面が真っ黒になる
  - 大量のフレームスキップ（100-175フレーム）
  - UIがフリーズする

 ### 原因
- Flutter 3.x の新しいImpellerレンダリングエンジンがAndroid 16でデフォルト有効
- Impellerレンダリングエンジン（Vulkanベース）がAndroid16で、複数のWebView/PlatformViewの同時初期化を処理できない。SDKが内部的に3-5個のWebViewインスタンスを同時生成することでリソース競合が発生。

 ### 解決策
  - AndroidManifest.xmlでImpellerレンダリングを無効化し、Skiaレンダラーにフォールバックすることで対応