### PR TITLE
fix: Update build configuration for Kotlin 2.0 and AGP 8.4+ compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ group = "com.example.caretailbooster_sdk"
 version = "1.0-SNAPSHOT"
 
 buildscript {
-    ext.kotlin_version = "1.9.10"
+    ext.kotlin_version = "2.0.0"
     repositories {
         google()
         mavenCentral()
@@ -11,6 +11,7 @@ buildscript {
     dependencies {
         classpath("com.android.tools.build:gradle:7.4.2")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version")
+        classpath("org.jetbrains.kotlin:compose-compiler-gradle-plugin:$kotlin_version")
     }
 }
 
@@ -42,10 +43,6 @@ android {
 
     buildFeatures {
         compose = true
-    }
-
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.3"
     }
 
     sourceSets {


### PR DESCRIPTION
## 概要
AGP 8.4+ およびKotlin 2.0との互換性を確保するためのビルド設定更新

## 変更内容
- `tasks.withType(JavaCompile) { options.release = 17 }` を削除（AGP 8.4+で非互換）
- Kotlin 1.9.10 → 2.0.0 へアップデート
- Compose Compilerプラグインを追加
- 非推奨の `kotlinCompilerExtensionVersion` を削除

## 理由
Android 15の16KBページサイズ対応のため、Kotlin 2.0へのアップデートが必要でした。
現状の設定ではAGP 8.4+でビルドエラーが発生するため、互換性のある記述への変更をお願いしたいです。